### PR TITLE
Support for tags not starting with 'v'

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -84,16 +84,16 @@ actions:
     update:
       - repo: iracelog-ansible-server-setup
         files: [group_vars/all/vars.yml]
-        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
       - repo: iracelog-deployment
         files: [compose/docker-compose.yml]
-        regex: '(?P<key>\s*image:\s*ghcr.io/mpapenbr/iracelog-service-manager-go:)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*image:\s*ghcr.io/mpapenbr/iracelog-service-manager-go:)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
       - repo: iracelog-deployment
         files: [k8s/helm/iracelog-app/values.yaml]
-        regex: '(?P<key>\s*ismVersion:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*ismVersion:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
       - repo: iracelog-documentation
         files: [versions.yml, README.adoc]
-        regex: '(?P<key>\s*iracelog-service-manager-go:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*iracelog-service-manager-go:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
       - repo: prod-provision
         branch: master
         repoType: Bitbucket
@@ -102,11 +102,11 @@ actions:
             newlayout/roles/apps/iracelog/vars/main.yml,
             newlayout/roles/apps/iracelog-aer/vars/main.yml,
           ]
-        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
       - repo: linux-provision
         repoType: Bitbucket
         files: [inventory/group_vars/all/iracelog.yml]
-        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)'
+        regex: '(?P<key>\s*iracelog_ism_go_version:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)'
 
   - from: iracelog-wamp-router
     update:

--- a/releaseupdater/replace_test.go
+++ b/releaseupdater/replace_test.go
@@ -8,6 +8,7 @@ import (
 // note: only the ?P<name> grouping variant is support in go
 const referenceRE = `(?P<key>\s*version:\s*)(?P<value>v.*?)(?P<other>$|\s+\.*)`
 const withQuotesRE = `(?P<key>\s*version:\s*")(?P<value>(v.*?))(?P<other>$|"|\s+\.*?)`
+const optionalV  = `(?P<key>\s*version:\s*)(?P<value>v?.*?)(?P<other>$|\s+\.*)`
 const complexInput = `
 version: v0.0.0-rc 
 
@@ -42,6 +43,8 @@ func TestReplaceVersionString(t *testing.T) {
 	}{
 		{name: "empty", args: args{content: "", regex: ".*", newVersion: "v1.0"}, want: "v1.0"},
 		{name: "invalid re", args: args{content: "", regex: "?<*", newVersion: "v1.0"}, want: ""},
+		{name: "optional v, no v in tag", args: args{content: "version: 0.0.0", regex: optionalV, newVersion: "v1.0"}, want: "version: v1.0"},
+		{name: "optional v, v in tag", args: args{content: "version: v0.0.0", regex: optionalV, newVersion: "v1.0"}, want: "version: v1.0"},
 		{name: "key value complete", args: args{content: "version: v0.0.0", regex: referenceRE, newVersion: "v1.0"}, want: "version: v1.0"},
 		{name: "with quotes", args: args{content: "version: \"v0.0.0\"", regex: withQuotesRE, newVersion: "v1.0"}, want: "version: \"v1.0\""},
 		{name: "complex multiline", args: args{
@@ -52,7 +55,7 @@ func TestReplaceVersionString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ReplaceVersionString(tt.args.content, tt.args.regex, tt.args.newVersion); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ReplaceVersion() = %v, want %v", got, tt.want)
+				t.Errorf("ReplaceVersion() = <%v>, want <%v>", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #16

Note: As this problem occured only on iracelog-service-manager-go the optional 'v' handling is only in effect for this source